### PR TITLE
Change to isAuraFile RegEx

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 
-// Check for /src/aura/Component/ComponentController.js or /src/aura/Component/ComponentHelper.js pattern
-export const isAuraFile = (filename) => /src\/aura\/[^\/]+\/.+(Controller|Helper).js$/.test(filename);
+// Check for ComponentController.js or ComponentHelper.js pattern
+export const isAuraFile = (filename) => /(Controller\.js$|Helper\.js$)/.test(filename);
 
 // Add module.exports for every aura file
 export const auraCodeTransformer = (code) => {


### PR DESCRIPTION
Not all projects use the project structure you have included in your reg ex.  This introduces folder flexibility and no errors as long as the developer is only using the lightning file naming conventions for lightning files.